### PR TITLE
Create async matcher

### DIFF
--- a/benchmarks/base.rb
+++ b/benchmarks/base.rb
@@ -1,0 +1,277 @@
+# frozen_string_literal: true
+
+# Operation result return time is static per mode:
+# - sync:  operation time + rules time + sampler (optional) + logger (optional)
+# - async: operation time (~ ASAP)
+
+# load gem from source
+# $: << File.expand_path("../../lib", __FILE__)
+
+require "contr"
+require "benchmark"
+
+class Contract < Contr::Act
+  sampler nil # do not rely on filesystem "consistency"
+
+  guarantee :g1 do |(task), _result|
+    task.call
+    true
+  end
+
+  guarantee :g2 do |(task), _result|
+    task.call
+    true
+  end
+
+  expect :e1 do |(task), _result|
+    task.call
+    false
+  end
+
+  expect :e2 do |(task), _result|
+    task.call
+    false # make contract fail to trigger logger
+  end
+end
+
+# logger is the last checking point in a failed contract
+# so it can be used to track the end of a contract
+class FakeLogger < Contr::Logger::Base
+  def initialize(latch)
+    @latch = latch
+  end
+
+  def log(_state)
+    @latch.count_down
+  end
+end
+
+class TrackableIO < Contr::Async::Pool::Base
+  def create_executor
+    Concurrent::ThreadPoolExecutor.new
+  end
+end
+
+class Base
+  def initialize(task:, checks:, operation: -> { 1 + 1 })
+    @task = task
+    @checks = checks
+    @operation = operation
+
+    @cpu_cores = Concurrent.processor_count
+    @thread_stats = {}
+  end
+
+  def run!
+    puts "time stats:"
+
+    Benchmark.bm(43) do |bm|
+      report(bm, "sync") do
+        sync
+      end
+
+      report(bm, "async | main: fixed, rules: nil") do
+        async(
+          main: Contr::Async::Pool::Fixed.new,
+          rules: nil
+        )
+      end
+
+      report(bm, "async | main: fixed (x2), rules: nil") do
+        async(
+          main: Contr::Async::Pool::Fixed.new(max_threads: @cpu_cores * 2),
+          rules: nil
+        )
+      end
+
+      report(bm, "async | main: fixed, rules: fixed") do
+        async(
+          main: Contr::Async::Pool::Fixed.new,
+          rules: Contr::Async::Pool::Fixed.new
+        )
+      end
+
+      report(bm, "async | main: fixed, rules: fixed (x2)") do
+        async(
+          main: Contr::Async::Pool::Fixed.new,
+          rules: Contr::Async::Pool::Fixed.new(max_threads: @cpu_cores * 2)
+        )
+      end
+
+      report(bm, "async | main: fixed (x2), rules: fixed (x2)") do
+        async(
+          main: Contr::Async::Pool::Fixed.new(max_threads: @cpu_cores * 2),
+          rules: Contr::Async::Pool::Fixed.new(max_threads: @cpu_cores * 2)
+        )
+      end
+
+      report(bm, "async | main: fixed, rules: io") do
+        async(
+          main: Contr::Async::Pool::Fixed.new,
+          rules: TrackableIO.new
+        )
+      end
+
+      report(bm, "async | main: fixed (x2), rules: io") do
+        async(
+          main: Contr::Async::Pool::Fixed.new(max_threads: @cpu_cores * 2),
+          rules: TrackableIO.new
+        )
+      end
+
+      report(bm, "async | main: io, rules: nil") do
+        async(
+          main: TrackableIO.new,
+          rules: nil
+        )
+      end
+
+      report(bm, "async | main: io, rules: fixed") do
+        async(
+          main: TrackableIO.new,
+          rules: Contr::Async::Pool::Fixed.new
+        )
+      end
+
+      report(bm, "async | main: io, rules: io") do
+        async(
+          main: TrackableIO.new,
+          rules: TrackableIO.new
+        )
+      end
+    end
+
+    print_thread_stats!
+  end
+
+  private
+
+  def report(bm, label)
+    contract = nil
+    time_stats = bm.report(label) { contract = yield }
+
+    calc_thread_stats(label, time_stats, contract)
+  end
+
+  def sync
+    contract = Contract.new(logger: nil)
+
+    @checks.times do
+      contract.check(@task) { @operation.call }
+    rescue Contr::Matcher::ExpectationsNotMatched
+      # exception can be ignored here
+    end
+
+    contract
+  end
+
+  def async(pools)
+    latch = Concurrent::CountDownLatch.new(@checks)
+    contract = Contract.new(async: {pools: pools}, logger: FakeLogger.new(latch))
+
+    @checks.times do
+      contract.check_async(@task) { @operation.call }
+    end
+
+    latch.wait
+
+    contract
+  end
+
+  def calc_thread_stats(label, time_stats, contract)
+    base = @thread_stats["sync"]
+
+    threads_main  = contract.main_pool.executor.largest_length if base
+    threads_rules = contract.rules_pool&.executor&.largest_length || 0 if base
+    threads_total = base ? threads_main + threads_rules : 1
+
+    change, time_diff = if base
+      base_time_real = base[:time_real]
+
+      if base_time_real > time_stats.real
+        [:decr, (base_time_real / time_stats.real).round(3)]
+      elsif base_time_real == time_stats.real
+        [:eq, 1.0]
+      else
+        [:incr, (time_stats.real / base_time_real).round(3)]
+      end
+    end
+
+    time_diff_per_thread = if base
+      ((time_diff - 1) / threads_total).round(5)
+    end
+
+    @thread_stats[label] = {
+      threads_main: threads_main,
+      threads_rules: threads_rules,
+      threads_total: threads_total,
+      time_real: time_stats.real,
+      change: change,
+      time_diff: time_diff,
+      time_diff_per_thread: time_diff_per_thread
+    }
+  end
+
+  def print_thread_stats!
+    headers = {
+      label:                "",
+      threads:              "total",
+      threads_per_pool:     "per pool",
+      time:                 "time",
+      change:               "+/-",
+      time_diff:            "diff",
+      time_diff_per_thread: "diff/thread"
+    }
+
+    rows = @thread_stats.map do |label, data|
+      threads_main  = data[:threads_main]  || "-"
+      threads_rules = data[:threads_rules] || "-"
+
+      threads_per_pool     = "#{threads_main.to_s.rjust(3)}/#{threads_rules.to_s.ljust(3)}"
+      change               = data[:change] ? format_change(data[:change]) : ""
+      time_diff            = data[:time_diff] ? "#{data[:time_diff]}x" : "-/-"
+      time_diff_per_thread = data[:time_diff_per_thread] ? "#{data[:time_diff_per_thread]}x" : "-/-"
+
+      {
+        label:                label,
+        threads:              data[:threads_total].to_s,
+        threads_per_pool:     threads_per_pool,
+        time:                 data[:time_real].round(3).to_s,
+        change:               change,
+        time_diff:            time_diff,
+        time_diff_per_thread: time_diff_per_thread
+      }
+    end
+
+    offsets = headers.each_with_object({}) do |(key, header), memo|
+      offset = [header.size, *rows.map { |data| data[key].size }].max
+      memo[key] = offset
+    end
+
+    headers_string = headers.map { |key, header| header.rjust(offsets[key]) }.join("  ")
+
+    rows_strings = rows.map do |row|
+      [
+        row[:label].ljust(offsets[:label]),
+        row[:threads].rjust(offsets[:threads]),
+        row[:threads_per_pool].rjust(offsets[:threads_per_pool]),
+        row[:time].rjust(offsets[:time]),
+        row[:change].ljust(2).rjust(offsets[:change]),
+        row[:time_diff].rjust(offsets[:time_diff]),
+        row[:time_diff_per_thread].rjust(offsets[:time_diff_per_thread])
+      ].join("  ")
+    end
+
+    puts "\n\nthread stats:"
+    puts headers_string
+    puts rows_strings.join("\n")
+  end
+
+  def format_change(change)
+    case change
+    when :decr then "⬇"
+    when :eq   then "="
+    when :incr then "⬆"
+    end
+  end
+end

--- a/benchmarks/cpu_task.rb
+++ b/benchmarks/cpu_task.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+def fib(n)
+  return n if (0..1).cover?(n)
+
+  fib(n - 1) + fib(n - 2)
+end
+
+if __FILE__ == $0
+  task = -> { fib(25) }
+
+  Base.new(task: task, checks: 100).run!
+end
+
+##
+# TL;DR
+#
+# - additional concurrency for CPU intensive tasks does not provide any viable time reduction
+#
+# ==============================================================================================
+#
+#                                       [ CHECKS: 50 ]
+# time stats:
+#                                                   user     system      total        real
+# sync                                          4.250881   0.019885   4.270766 (  4.290467)
+# async | main: fixed, rules: nil               4.235206   0.021865   4.257071 (  4.267535)
+# async | main: fixed (x2), rules: nil          4.212905   0.051009   4.263914 (  4.272508)
+# async | main: fixed, rules: fixed             4.274388   0.072532   4.346920 (  4.360085)
+# async | main: fixed, rules: fixed (x2)        4.282669   0.055192   4.337861 (  4.356116)
+# async | main: fixed (x2), rules: fixed (x2)   4.227645   0.087375   4.315020 (  4.317907)
+# async | main: fixed, rules: io                4.190892   0.081147   4.272039 (  4.271017)
+# async | main: fixed (x2), rules: io           4.195734   0.080313   4.276047 (  4.274868)
+# async | main: io, rules: nil                  4.160617   0.077557   4.238174 (  4.237149)
+# async | main: io, rules: fixed                4.192927   0.082717   4.275644 (  4.274397)
+# async | main: io, rules: io                   4.201217   0.083978   4.285195 (  4.283295)
+#
+#
+# thread stats:
+#                                              total  per pool   time  +/-    diff  diff/thread
+# sync                                             1     -/-     4.29          -/-          -/-
+# async | main: fixed, rules: nil                 10    10/0    4.268   ⬇   1.005x      0.0005x
+# async | main: fixed (x2), rules: nil            20    20/0    4.273   ⬇   1.004x      0.0002x
+# async | main: fixed, rules: fixed               20    10/10    4.36   ⬆   1.016x      0.0008x
+# async | main: fixed, rules: fixed (x2)          30    10/20   4.356   ⬆   1.015x      0.0005x
+# async | main: fixed (x2), rules: fixed (x2)     40    20/20   4.318   ⬆   1.006x     0.00015x
+# async | main: fixed, rules: io                  50    10/40   4.271   ⬇   1.005x      0.0001x
+# async | main: fixed (x2), rules: io            100    20/80   4.275   ⬇   1.004x     4.0e-05x
+# async | main: io, rules: nil                    50    50/0    4.237   ⬇   1.013x     0.00026x
+# async | main: io, rules: fixed                  60    50/10   4.274   ⬇   1.004x     7.0e-05x
+# async | main: io, rules: io                    250    50/200  4.283   ⬇   1.002x     1.0e-05x
+#
+# ==============================================================================================
+#
+#                                       [ CHECKS: 100 ]
+# time stats:
+#                                                   user     system      total        real
+# sync                                          8.543808   0.104893   8.648701 (  8.669669)
+# async | main: fixed, rules: nil               8.357270   0.149115   8.506385 (  8.504923)
+# async | main: fixed (x2), rules: nil          8.415800   0.155927   8.571727 (  8.582525)
+# async | main: fixed, rules: fixed             8.513098   0.071150   8.584248 (  8.596497)
+# async | main: fixed, rules: fixed (x2)        8.447333   0.027577   8.474910 (  8.476787)
+# async | main: fixed (x2), rules: fixed (x2)   8.612738   0.051878   8.664616 (  8.683243)
+# async | main: fixed, rules: io                8.480218   0.037807   8.518025 (  8.565940)
+# async | main: fixed (x2), rules: io           8.439694   0.031848   8.471542 (  8.483056)
+# async | main: io, rules: nil                  8.372477   0.026578   8.399055 (  8.404046)
+# async | main: io, rules: fixed                8.424610   0.030532   8.455142 (  8.457499)
+# async | main: io, rules: io                   8.567914   0.046685   8.614599 (  8.609780)
+#
+#
+# thread stats:
+#                                              total  per pool   time  +/-    diff  diff/thread
+# sync                                             1     -/-     8.67          -/-          -/-
+# async | main: fixed, rules: nil                 10    10/0    8.505   ⬇   1.019x      0.0019x
+# async | main: fixed (x2), rules: nil            20    20/0    8.583   ⬇    1.01x      0.0005x
+# async | main: fixed, rules: fixed               20    10/10   8.596   ⬇   1.009x     0.00045x
+# async | main: fixed, rules: fixed (x2)          30    10/20   8.477   ⬇   1.023x     0.00077x
+# async | main: fixed (x2), rules: fixed (x2)     40    20/20   8.683   ⬆   1.002x     5.0e-05x
+# async | main: fixed, rules: io                  50    10/40   8.566   ⬇   1.012x     0.00024x
+# async | main: fixed (x2), rules: io            100    20/80   8.483   ⬇   1.022x     0.00022x
+# async | main: io, rules: nil                   100   100/0    8.404   ⬇   1.032x     0.00032x
+# async | main: io, rules: fixed                 110   100/10   8.457   ⬇   1.025x     0.00023x
+# async | main: io, rules: io                    500   100/400   8.61   ⬇   1.007x     1.0e-05
+#
+# ==============================================================================================
+#
+#                                       [ CHECKS: 200 ]
+# time stats:
+#                                                   user     system      total        real
+# sync                                         16.830111   0.037023  16.867134 ( 16.875315)
+# async | main: fixed, rules: nil              16.645972   0.034002  16.679974 ( 16.674489)
+# async | main: fixed (x2), rules: nil         16.850945   0.048107  16.899052 ( 16.908938)
+# async | main: fixed, rules: fixed            17.079214   0.074882  17.154096 ( 17.164638)
+# async | main: fixed, rules: fixed (x2)       16.974090   0.071376  17.045466 ( 17.049899)
+# async | main: fixed (x2), rules: fixed (x2)  17.110340   0.100503  17.210843 ( 17.233636)
+# async | main: fixed, rules: io               16.875315   0.058312  16.933627 ( 16.935570)
+# async | main: fixed (x2), rules: io          16.928882   0.062430  16.991312 ( 16.998766)
+# async | main: io, rules: nil                 16.797027   0.066425  16.863452 ( 16.869656)
+# async | main: io, rules: fixed               16.978877   0.084309  17.063186 ( 17.085429)
+# async | main: io, rules: io                  16.878359   0.136590  17.014949 ( 16.989438)
+#
+#
+# thread stats:
+#                                              total  per pool    time  +/-    diff  diff/thread
+# sync                                             1     -/-    16.875          -/-          -/-
+# async | main: fixed, rules: nil                 10    10/0    16.674   ⬇   1.012x      0.0012x
+# async | main: fixed (x2), rules: nil            20    20/0    16.909   ⬆   1.002x      0.0001x
+# async | main: fixed, rules: fixed               20    10/10   17.165   ⬆   1.017x     0.00085x
+# async | main: fixed, rules: fixed (x2)          30    10/20    17.05   ⬆    1.01x     0.00033x
+# async | main: fixed (x2), rules: fixed (x2)     40    20/20   17.234   ⬆   1.021x     0.00052x
+# async | main: fixed, rules: io                  50    10/40   16.936   ⬆   1.004x     8.0e-05x
+# async | main: fixed (x2), rules: io            100    20/80   16.999   ⬆   1.007x     7.0e-05x
+# async | main: io, rules: nil                   200   200/0     16.81   ⬇   1.004x     0.00502x
+# async | main: io, rules: fixed                 210   200/10   17.085   ⬆   1.012x     6.0e-05x
+# async | main: io, rules: io                   1000   200/800  16.989   ⬆   1.007x     1.0e-05x
+#
+# ===============================================================================================

--- a/benchmarks/io_task.rb
+++ b/benchmarks/io_task.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+if __FILE__ == $0
+  task = -> { sleep(0.3) }
+
+  Base.new(task: task, checks: 200).run!
+end
+
+##
+# TL;DR
+#
+# - while `io` provides the best performance it does not have max_threads limit (almost), so it's
+#   pretty easy to overload the system with excessive number of threads, especially with the high
+#   number of contract check invocations
+# - it's comparably safe to use `io` for rules pool while `fixed` main pool works like a limiting
+#   factor preventing `io` from indefinite creation of threads
+# - increasing number of threads in main pool with disabled rules pool is more effective than having
+#   the same number of threads across both of them enabled, i.e. configurations `fixed/fixed` should
+#   be avoided
+#
+# Pool configs compared:
+#   fixed/nil   | yes   | predictable, linear performance boost
+#   fixed/io    | yes   | predictable, great performance (warning: more threads involved)
+#   fixed/fixed | no    | wasting threads, fixed/nil is more efficient
+#   io/nil      | maybe | no max_threads limit, great performance, safe only for infrequent checks
+#   io/io       | maybe | no max_threads limit, best performance, safe only for infrequent checks
+#   io/fixed    | no    | `fixed` pool blocks `io` pool giving the same performance as `fixed/nil`
+#                         config while consuming a lot more threads
+#
+# ===============================================================================================
+#
+#                                       [ CHECKS: 50 ]
+# time stats:
+#                                                   user     system      total        real
+# sync                                          0.029054   0.003960   0.033014 ( 60.730443)
+# async | main: fixed, rules: nil               0.037581   0.006289   0.043870 (  6.102996)
+# async | main: fixed (x2), rules: nil          0.013672   0.006369   0.020041 (  3.658370)
+# async | main: fixed, rules: fixed             0.045739   0.009818   0.055557 (  6.105275)
+# async | main: fixed, rules: fixed (x2)        0.048882   0.007210   0.056092 (  3.058503)
+# async | main: fixed (x2), rules: fixed (x2)   0.061931   0.009909   0.071840 (  3.081287)
+# async | main: fixed, rules: io                0.048239   0.010111   0.058350 (  1.575488)
+# async | main: fixed (x2), rules: io           0.062420   0.012960   0.075380 (  0.993189)
+# async | main: io, rules: nil                  0.010998   0.006536   0.017534 (  1.235455)
+# async | main: io, rules: fixed                0.050765   0.014542   0.065307 (  6.115675)
+# async | main: io, rules: io                   0.041993   0.020064   0.062057 (  0.370872)
+#
+#
+# thread stats:
+#                                              total  per pool   time  +/-     diff  diff/thread
+# sync                                             1     -/-    60.73           -/-          -/-
+# async | main: fixed, rules: nil                 10    10/0    6.103   ⬇    9.951x      0.8951x
+# async | main: fixed (x2), rules: nil            20    20/0    3.658   ⬇     16.6x        0.78x
+# async | main: fixed, rules: fixed               20    10/10   6.105   ⬇    9.947x     0.44735x
+# async | main: fixed, rules: fixed (x2)          30    10/20   3.059   ⬇   19.856x     0.62853x
+# async | main: fixed (x2), rules: fixed (x2)     40    20/20   3.081   ⬇   19.709x     0.46773x
+# async | main: fixed, rules: io                  50    10/40   1.575   ⬇   38.547x     0.75094x
+# async | main: fixed (x2), rules: io            100    20/80   0.993   ⬇   61.147x     0.60147x
+# async | main: io, rules: nil                    50    50/0    1.235   ⬇   49.156x     0.96312x
+# async | main: io, rules: fixed                  60    50/10   6.116   ⬇     9.93x     0.14883x
+# async | main: io, rules: io                    250    50/200  0.371   ⬇   163.75x       0.651x
+#
+# ===============================================================================================
+#
+#                                       [ CHECKS: 100 ]
+# time stats:
+#                                                   user     system      total        real
+# sync                                          0.055339   0.008615   0.063954 (121.464142)
+# async | main: fixed, rules: nil               0.028633   0.010361   0.038994 ( 12.177779)
+# async | main: fixed (x2), rules: nil          0.037569   0.010526   0.048095 (  6.106619)
+# async | main: fixed, rules: fixed             0.105311   0.018323   0.123634 ( 12.197988)
+# async | main: fixed, rules: fixed (x2)        0.096907   0.013051   0.109958 (  6.114231)
+# async | main: fixed (x2), rules: fixed (x2)   0.105981   0.014082   0.120063 (  6.104263)
+# async | main: fixed, rules: io                0.082036   0.018177   0.100213 (  3.107185)
+# async | main: fixed (x2), rules: io           0.112657   0.025035   0.137692 (  1.648126)
+# async | main: io, rules: nil                  0.050145   0.017948   0.068093 (  1.256689)
+# async | main: io, rules: fixed                0.086865   0.032995   0.119860 ( 12.211977)
+# async | main: io, rules: io                   0.087008   0.049833   0.136841 (  0.425713)
+#
+#
+# thread stats:
+#                                              total  per pool     time  +/-      diff  diff/thread
+# sync                                             1     -/-    121.464            -/-          -/-
+# async | main: fixed, rules: nil                 10    10/0     12.178   ⬇     9.974x      0.8974x
+# async | main: fixed (x2), rules: nil            20    20/0      6.107   ⬇    19.891x     0.94455x
+# async | main: fixed, rules: fixed               20    10/10    12.198   ⬇     9.958x      0.4479x
+# async | main: fixed, rules: fixed (x2)          30    10/20     6.114   ⬇    19.866x     0.62887x
+# async | main: fixed (x2), rules: fixed (x2)     40    20/20     6.104   ⬇    19.898x     0.47245x
+# async | main: fixed, rules: io                  50    10/40     3.107   ⬇    39.091x     0.76182x
+# async | main: fixed (x2), rules: io            100    20/80     1.648   ⬇    73.698x     0.72698x
+# async | main: io, rules: nil                   100   100/0      1.257   ⬇    96.654x     0.95654x
+# async | main: io, rules: fixed                 110   100/10    12.212   ⬇     9.946x     0.08133x
+# async | main: io, rules: io                    500   100/400    0.426   ⬇   285.319x     0.56864x
+#
+# ==================================================================================================
+#
+#                                       [ CHECKS: 200 ]
+# time stats:
+#                                                   user     system      total        real
+# sync                                          0.141575   0.016051   0.157626 (243.061935)
+# async | main: fixed, rules: nil               0.047256   0.020366   0.067622 ( 24.305634)
+# async | main: fixed (x2), rules: nil          0.071847   0.019492   0.091339 ( 12.183187)
+# async | main: fixed, rules: fixed             0.240031   0.028739   0.268770 ( 24.320212)
+# async | main: fixed, rules: fixed (x2)        0.201068   0.028274   0.229342 ( 12.187651)
+# async | main: fixed (x2), rules: fixed (x2)   0.167911   0.030028   0.197939 ( 12.196199)
+# async | main: fixed, rules: io                0.138820   0.038072   0.176892 (  6.252542)
+# async | main: fixed (x2), rules: io           0.106197   0.039303   0.145500 (  3.171551)
+# async | main: io, rules: nil                  0.046821   0.044440   0.091261 (  1.261595)
+# async | main: io, rules: fixed                0.152188   0.075875   0.228063 ( 24.370940)
+# async | main: io, rules: io                   0.125763   0.186338   0.312101 (  0.492362)
+#
+#
+# thread stats:
+#                                              total  per pool     time  +/-      diff  diff/thread
+# sync                                             1     -/-    243.062            -/-          -/-
+# async | main: fixed, rules: nil                 10    10/0     24.306   ⬇      10.0x         0.9x
+# async | main: fixed (x2), rules: nil            20    20/0     12.183   ⬇    19.951x     0.94755x
+# async | main: fixed, rules: fixed               20    10/10     24.32   ⬇     9.994x      0.4497x
+# async | main: fixed, rules: fixed (x2)          30    10/20    12.188   ⬇    19.943x     0.63143x
+# async | main: fixed (x2), rules: fixed (x2)     40    20/20    12.196   ⬇    19.929x     0.47322x
+# async | main: fixed, rules: io                  50    10/40     6.253   ⬇    38.874x     0.75748x
+# async | main: fixed (x2), rules: io            100    20/80     3.172   ⬇    76.638x     0.75638x
+# async | main: io, rules: nil                   200   200/0      1.262   ⬇   192.662x     0.95831x
+# async | main: io, rules: fixed                 210   200/10    24.371   ⬇     9.973x     0.04273x
+# async | main: io, rules: io                   1000   200/800    0.492   ⬇   493.665x     0.49267x
+#
+# ==================================================================================================

--- a/contr.gemspec
+++ b/contr.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.7"
+
+  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
 end

--- a/examples/contract_matched.rb
+++ b/examples/contract_matched.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# load gem from source
+# $: << File.expand_path("../../lib", __FILE__)
+
+require "contr"
+
+class SumContract < Contr::Act
+  guarantee :result_is_float do |(_), result|
+    result.is_a?(Float)
+  end
+
+  guarantee :result_is_positive do |(_), result|
+    result > 0
+  end
+
+  guarantee :args_are_numbers do |args|
+    args.all? { |arg| arg.is_a?(Numeric) }
+  end
+
+  expect :arg_1_is_float do |(arg_1, _)|
+    arg_1.is_a?(Float)
+  end
+
+  expect :arg_2_is_float do |(_, arg_2)|
+    arg_2.is_a?(Float)
+  end
+end
+
+args = [1, 2.0]
+contract = SumContract.new
+
+contract.check(*args) { args.inject(:+) }
+# => 3.0
+
+contract.check_async(*args) { args.inject(:+) }
+# => 3.0
+# (no state dump, no log)

--- a/examples/expectations_not_matched.rb
+++ b/examples/expectations_not_matched.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+# load gem from source
+# $: << File.expand_path("../../lib", __FILE__)
+
+require "contr"
+
+class SumContract < Contr::Act
+  guarantee :result_is_float do |(_), result|
+    result.is_a?(Float)
+  end
+
+  guarantee :result_is_positive do |(_), result|
+    result > 0
+  end
+
+  guarantee :args_are_numbers do |args|
+    args.all? { |arg| arg.is_a?(Numeric) }
+  end
+
+  expect :arg_1_is_float do |(arg_1, _)|
+    arg_1.is_a?(Float)
+  end
+
+  expect :arg_2_is_integer do |(_, arg_2)|
+    arg_2.is_a?(Integer)
+  end
+end
+
+args = [1, 2.0]
+contract = SumContract.new
+
+contract.check(*args) { args.inject(:+) }
+# => Contr::Matcher::ExpectationsNotMatched: failed rules: [[:expectation, :arg_1_is_float, :failed], [:expectation, :arg_2_is_integer, :failed]], args: [1, 2.0]
+
+# [if previous dump doesn't exist]
+#
+# state dumped to: /tmp/contracts/SumContract/2850248.dump
+# state:
+# {
+#   ts:            "2024-03-11T09:23:04.245Z",
+#   contract_name: "SumContract",
+#   failed_rules: [
+#     {type: :expectation, name: :arg_1_is_float, status: :failed},
+#     {type: :expectation, name: :arg_2_is_integer, status: :failed}
+#   ],
+#   ok_rules: [
+#     {type: :guarantee, name: :result_is_float, status: :ok},
+#     {type: :guarantee, name: :result_is_positive, status: :ok},
+#     {type: :guarantee, name: :args_are_numbers, status: :ok}
+#   ],
+#   async:  false,
+#   args:   [1, 2.0],
+#   result: 3.0
+# }
+#
+# log:
+# D, [2024-03-11T11:23:04.245811 #71262] DEBUG -- : {"ts":"2024-03-11T09:23:04.245Z","contract_name":"SumContract","failed_rules":[{"type":"expectation","name":"arg_1_is_float","status":"failed"},{"type":"expectation","name":"arg_2_is_integer","status":"failed"}],"ok_rules":[{"type":"guarantee","name":"result_is_float","status":"ok"},{"type":"guarantee","name":"result_is_positive","status":"ok"},{"type":"guarantee","name":"args_are_numbers","status":"ok"}],"async":false,"args":[1,2.0],"result":3.0,"dump_info":{"path":"/tmp/contracts/SumContract/2850248.dump"},"tag":"contract-failed"}
+
+# [if previous dump exists]
+#
+# state is not dumped once again (10 minutes window by default), but still logged - without `dump_info` field this time
+#
+# log:
+# D, [2024-03-11T11:23:04.245811 #71262] DEBUG -- : {"ts":"2024-03-11T09:23:04.245Z","contract_name":"SumContract","failed_rules":[{"type":"expectation","name":"arg_1_is_float","status":"failed"},{"type":"expectation","name":"arg_2_is_integer","status":"failed"}],"ok_rules":[{"type":"guarantee","name":"result_is_float","status":"ok"},{"type":"guarantee","name":"result_is_positive","status":"ok"},{"type":"guarantee","name":"args_are_numbers","status":"ok"}],"async":false,"args":[1,2.0],"result":3.0,"tag":"contract-failed"}
+
+contract.check_async(*args) { args.inject(:+) }
+# => 3.0
+
+# [if previous dump doesn't exist]
+#
+# state dumped to: /tmp/contracts/SumContract/2850248.dump
+# state:
+# {
+#   ts:            "2024-03-11T09:23:04.245Z",
+#   contract_name: "SumContract",
+#   failed_rules: [
+#     {type: :expectation, name: :arg_1_is_float, status: :failed},
+#     {type: :expectation, name: :arg_2_is_integer, status: :failed}
+#   ],
+#   ok_rules: [
+#     {type: :guarantee, name: :result_is_float, status: :ok},
+#     {type: :guarantee, name: :result_is_positive, status: :ok},
+#     {type: :guarantee, name: :args_are_numbers, status: :ok}
+#   ],
+#   async:  true,
+#   args:   [1, 2.0],
+#   result: 3.0
+# }
+#
+# log:
+# D, [2024-03-11T11:23:04.245811 #71262] DEBUG -- : {"ts":"2024-03-11T09:23:04.245Z","contract_name":"SumContract","failed_rules":[{"type":"expectation","name":"arg_1_is_float","status":"failed"},{"type":"expectation","name":"arg_2_is_integer","status":"failed"}],"ok_rules":[{"type":"guarantee","name":"result_is_float","status":"ok"},{"type":"guarantee","name":"result_is_positive","status":"ok"},{"type":"guarantee","name":"args_are_numbers","status":"ok"}],"async":true,"args":[1,2.0],"result":3.0,"dump_info":{"path":"/tmp/contracts/SumContract/2850248.dump"},"tag":"contract-failed"}
+
+# [if previous dump exists]
+#
+# state is not dumped once again (10 minutes window by default), but still logged - without `dump_info` field this time
+#
+# log:
+# D, [2024-03-11T11:23:04.245811 #71262] DEBUG -- : {"ts":"2024-03-11T09:23:04.245Z","contract_name":"SumContract","failed_rules":[{"type":"expectation","name":"arg_1_is_float","status":"failed"},{"type":"expectation","name":"arg_2_is_integer","status":"failed"}],"ok_rules":[{"type":"guarantee","name":"result_is_float","status":"ok"},{"type":"guarantee","name":"result_is_positive","status":"ok"},{"type":"guarantee","name":"args_are_numbers","status":"ok"}],"async":true,"args":[1,2.0],"result":3.0,"tag":"contract-failed"}

--- a/examples/guarantees_not_matched.rb
+++ b/examples/guarantees_not_matched.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# load gem from source
+# $: << File.expand_path("../../lib", __FILE__)
+
+require "contr"
+
+class SumContract < Contr::Act
+  guarantee :result_is_float do |(_), result|
+    result.is_a?(Float)
+  end
+
+  guarantee :result_is_positive do |(_), result|
+    result > 0
+  end
+
+  guarantee :args_are_numbers do |args|
+    args.all? { |arg| arg.is_a?(Numeric) }
+  end
+
+  expect :arg_1_is_float do |(arg_1, _)|
+    arg_1.is_a?(Float)
+  end
+
+  expect :arg_2_is_float do |(_, arg_2)|
+    arg_2.is_a?(Float)
+  end
+end
+
+args = [1, -2.0]
+contract = SumContract.new
+
+contract.check(*args) { args.inject(:+) }
+# => Contr::Matcher::GuaranteesNotMatched: failed rules: [[:guarantee, :result_is_positive, :failed]], args: [1, -2.0]
+
+# [if previous dump doesn't exist]
+#
+# state dumped to: /tmp/contracts/SumContract/2850248.dump
+# state:
+# {
+#   ts:            "2024-03-11T09:23:04.245Z",
+#   contract_name: "SumContract",
+#   failed_rules:  [{type: :guarantee, name: :result_is_positive, status: :failed}],
+#   ok_rules:      [{type: :guarantee, name: :result_is_float, status: :ok}],
+#   async:         false,
+#   args:          [1, -2.0],
+#   result:        -1.0
+# }
+#
+# log:
+# D, [2024-03-11T11:23:04.245811 #71262] DEBUG -- : {"ts":"2024-03-11T09:23:04.245Z","contract_name":"SumContract","failed_rules":[{"type":"guarantee","name":"result_is_positive","status":"failed"}],"ok_rules":[{"type":"guarantee","name":"result_is_float","status":"ok"}],"async":false,"args":[1,-2.0],"result":-1.0,"dump_info":{"path":"/tmp/contracts/SumContract/2850248.dump"},"tag":"contract-failed"}
+
+# [if previous dump exists]
+#
+# state is not dumped once again (10 minutes window by default), but still logged - without `dump_info` field this time
+#
+# log:
+# D, [2024-03-11T11:23:04.245811 #71262] DEBUG -- : {"ts":"2024-03-11T09:23:04.245Z","contract_name":"SumContract","failed_rules":[{"type":"guarantee","name":"result_is_positive","status":"failed"}],"ok_rules":[{"type":"guarantee","name":"result_is_float","status":"ok"}],"async":false,"args":[1,-2.0],"result":-1.0,"tag":"contract-failed"}
+
+contract.check_async(*args) { args.inject(:+) }
+# => -1.0
+
+# [if previous dump doesn't exist]
+#
+# state dumped to: /tmp/contracts/SumContract/2850248.dump
+# state:
+# {
+#   ts:            "2024-03-11T09:23:04.245Z",
+#   contract_name: "SumContract",
+#   failed_rules:  [{type: :guarantee, name: :result_is_positive, status: :failed}],
+#   ok_rules:      [{type: :guarantee, name: :result_is_float, status: :ok}],
+#   async:         true,
+#   args:          [1, -2.0],
+#   result:        -1.0
+# }
+#
+# log:
+# D, [2024-03-11T11:23:04.245811 #71262] DEBUG -- : {"ts":"2024-03-11T09:23:04.245Z","contract_name":"SumContract","failed_rules":[{"type":"guarantee","name":"result_is_positive","status":"failed"}],"ok_rules":[{"type":"guarantee","name":"result_is_float","status":"ok"}],"async":true,"args":[1,-2.0],"result":-1.0,"dump_info":{"path":"/tmp/contracts/SumContract/2850248.dump"},"tag":"contract-failed"}
+
+# [if previous dump exists]
+#
+# state is not dumped once again (10 minutes window by default), but still logged - without `dump_info` field this time
+#
+# log:
+# D, [2024-03-11T11:23:04.245811 #71262] DEBUG -- : {"ts":"2024-03-11T09:23:04.245Z","contract_name":"SumContract","failed_rules":[{"type":"guarantee","name":"result_is_positive","status":"failed"}],"ok_rules":[{"type":"guarantee","name":"result_is_float","status":"ok"}],"async":true,"args":[1,-2.0],"result":-1.0,"tag":"contract-failed"}

--- a/lib/contr.rb
+++ b/lib/contr.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
 require_relative "contr/version"
+require_relative "contr/refines/hash"
+require_relative "contr/async/pool"
+require_relative "contr/async/pool/fixed"
+require_relative "contr/async/pool/global_io"
 require_relative "contr/logger"
 require_relative "contr/logger/default"
 require_relative "contr/sampler"
 require_relative "contr/sampler/default"
 require_relative "contr/matcher"
 require_relative "contr/matcher/sync"
+require_relative "contr/matcher/async"
 require_relative "contr/base"
 
 module Contr

--- a/lib/contr/async/pool.rb
+++ b/lib/contr/async/pool.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "concurrent-ruby"
+
+module Contr
+  module Async
+    module Pool
+      class Base
+        def executor
+          @executor ||= create_executor
+        end
+
+        def create_executor
+          raise NotImplementedError, "pool should implement `#create_executor` method"
+        end
+
+        def future(*args, &block)
+          Concurrent::Promises.future_on(executor, *args, &block)
+        end
+
+        def zip(*futures)
+          Concurrent::Promises.zip_futures_on(executor, *futures)
+        end
+      end
+    end
+  end
+end

--- a/lib/contr/async/pool/fixed.rb
+++ b/lib/contr/async/pool/fixed.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Contr
+  module Async
+    module Pool
+      class Fixed < Pool::Base
+        def initialize(max_threads: Concurrent.processor_count)
+          @max_threads = max_threads
+        end
+
+        def create_executor
+          Concurrent::ThreadPoolExecutor.new(
+            min_threads:     0,
+            max_threads:     @max_threads,
+            auto_terminate:  true,
+            idletime:        60,           # 1 minute
+            max_queue:       0,            # unlimited
+            fallback_policy: :caller_runs  # doesn't matter - max_queue 0
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/contr/async/pool/global_io.rb
+++ b/lib/contr/async/pool/global_io.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Contr
+  module Async
+    module Pool
+      class GlobalIO < Pool::Base
+        def create_executor
+          Concurrent.global_io_executor
+        end
+      end
+    end
+  end
+end

--- a/lib/contr/matcher/async.rb
+++ b/lib/contr/matcher/async.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Contr
+  class Matcher
+    class Async < Matcher::Base
+      def initialize(*)
+        super
+
+        @async = true
+        @ok_rules = Concurrent::Array.new
+        @failed_rules = Concurrent::Array.new
+      end
+
+      def match
+        contract_future = main_pool.future do
+          contract_failed = rules_pool ? check_with_async_rules : check_with_sync_rules
+
+          dump_state! if contract_failed
+        end
+
+        contract_future.wait! if inline?
+      end
+
+      private
+
+      def check_with_async_rules
+        checked_rules = rules_pool.zip(
+          *futures_from(guarantees),
+          *futures_from(expectations)
+        ).value!
+
+        checked_guarantees, checked_expectations = checked_rules.partition { |rule| rule[:type] == :guarantee }
+
+        guarantees_failed   = any_failed?(checked_guarantees)
+        expectations_failed = all_failed?(checked_expectations)
+
+        guarantees_failed || expectations_failed
+      end
+
+      def check_with_sync_rules
+        any_failed?(guarantees) || all_failed?(expectations)
+      end
+
+      def futures_from(rules)
+        rules.map do |rule|
+          rules_pool.future(rule) do |rule|
+            check_rule(rule)
+          end
+        end
+      end
+
+      # for testing purposes
+      def inline?
+        false
+      end
+    end
+  end
+end

--- a/lib/contr/matcher/sync.rb
+++ b/lib/contr/matcher/sync.rb
@@ -12,36 +12,11 @@ module Contr
       end
 
       def match
-        guarantees_matched?   || dump_state_and_raise(GuaranteesNotMatched)
-        expectations_matched? || dump_state_and_raise(ExpectationsNotMatched)
+        any_failed?(guarantees)   && dump_state_and_raise(GuaranteesNotMatched)
+        all_failed?(expectations) && dump_state_and_raise(ExpectationsNotMatched)
       end
 
       private
-
-      def guarantees_matched?
-        return true if @guarantees.empty?
-
-        @guarantees.all? { |rule| ok_rule?(rule) }
-      end
-
-      def expectations_matched?
-        return true if @expectations.empty?
-
-        @expectations.any? { |rule| ok_rule?(rule) }
-      end
-
-      def ok_rule?(rule)
-        match_result = match_rule(rule)
-        checked_rule = rule.slice(:type, :name).merge!(match_result)
-
-        if match_result[:status] == :ok
-          @ok_rules << checked_rule
-          true
-        else
-          @failed_rules << checked_rule
-          false
-        end
-      end
 
       def dump_state_and_raise(error_class)
         dump_state!

--- a/lib/contr/refines/hash.rb
+++ b/lib/contr/refines/hash.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Refines
+  module Hash
+    refine ::Hash do
+      def deep_merge(other_hash)
+        merge(other_hash) do |_key, this_value, other_value|
+          if this_value.is_a?(::Hash) && other_value.is_a?(::Hash)
+            this_value.deep_merge(other_value)
+          else
+            other_value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/contr/sampler/default.rb
+++ b/lib/contr/sampler/default.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "fileutils"
+
 module Contr
   class Sampler
     class Default < Sampler::Base

--- a/spec/contr/async/pool/fixed_spec.rb
+++ b/spec/contr/async/pool/fixed_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe Contr::Async::Pool::Fixed do
+  subject(:pool) { described_class.new }
+
+  it "has correct attributes" do
+    expect(pool).to be_fixed_async_pool
+  end
+end

--- a/spec/contr/async/pool/global_io_spec.rb
+++ b/spec/contr/async/pool/global_io_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe Contr::Async::Pool::GlobalIO do
+  subject(:pool) { described_class.new }
+
+  it "has correct attributes" do
+    expect(pool).to be_global_io_async_pool
+  end
+end

--- a/spec/contr/async/pool_spec.rb
+++ b/spec/contr/async/pool_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe Contr::Async::Pool do
+  include ClassHelpers
+
+  describe described_class::Base do
+    context "when pool does not implement `#create_executor`" do
+      before do
+        define_class("AnotherPool", described_class)
+      end
+
+      subject(:executor) { AnotherPool.new.executor }
+
+      it "raises an error" do
+        expect { executor }.to raise_error(
+          NotImplementedError,
+          "pool should implement `#create_executor` method"
+        )
+      end
+    end
+  end
+end

--- a/spec/contr/base/shared_contexts/contract_check_setup.rb
+++ b/spec/contr/base/shared_contexts/contract_check_setup.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "contract check setup" do
+  before :all do
+    Timecop.freeze(Time.utc(1999))
+    @dump_folder = "/tmp/contract_tests/#{SecureRandom.uuid}"
+    @dump_period_id = "1525248"
+  end
+
+  after :all do
+    Timecop.return
+  end
+
+  after do
+    FileUtils.rm_rf(@dump_folder)
+  end
+
+  before do
+    # fixes visibility in block passed to `define_contract_class`
+    dump_folder = @dump_folder
+
+    define_contract_class("PreConfiguredContract") do
+      logger Contr::Logger::Default.new(stream: IO::NULL)
+      sampler Contr::Sampler::Default.new(folder: dump_folder)
+    end
+  end
+
+  let(:contract)         { Object.const_get(contract_name).new }
+  let(:operation)        { proc { 1 + 1 } }
+  let(:operation_result) { 2 }
+  let(:args)             { [1, 2, 3] }
+
+  let(:dump_info) { {path: "#{@dump_folder}/#{contract_name}/#{@dump_period_id}.dump"} }
+  let(:log_state) { state.merge(dump_info: dump_info) }
+
+  def expect_log_with(*args)
+    expect(contract.logger).to receive(:log).with(*args).once.and_call_original
+  end
+
+  def expect_sample_with(*args)
+    expect(contract.sampler).to receive(:sample!).with(*args).once.and_call_original
+  end
+
+  def not_expect_log
+    expect(contract.logger).not_to receive(:log)
+  end
+
+  def not_expect_sample
+    expect(contract.sampler).not_to receive(:sample!)
+  end
+end

--- a/spec/contr/base/shared_examples/contract_check.rb
+++ b/spec/contr/base/shared_examples/contract_check.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "contract check" do
+  context "different ways of handling args in rules" do
+    before do
+      define_contract_class(contract_name, BaseContract) do
+        guarantee(:g1) { true }
+        guarantee(:g2) { |(arg_0, _)| arg_0 == 0 }
+        guarantee(:g3) { |(arg_0, *)| arg_0 == 0 }
+        guarantee(:g4) { |(_, arg_1)| arg_1 == 1 }
+        guarantee(:g5) { |(*, arg_1)| arg_1 == 1 }
+        guarantee(:g6) { |(_), result| result == 2 }
+        guarantee(:g7) { |(arg_0, arg_1), _| arg_0 == 0 && arg_1 == 1 }
+        guarantee(:g8) { |args, result| args == [0, 1] && result == 2 }
+        expect(:e1)    { |(arg_0, arg_1), result| arg_0 == 0 && arg_1 == 1 && result == 2 }
+      end
+    end
+
+    let(:contract_name) { "ContractWithAllPossibleArgs" }
+    let(:args)          { [0, 1] }
+
+    it "makes args available for all the rules" do
+      expect(result).to eq operation_result
+    end
+  end
+
+  context "when checked operation raises an error" do
+    let(:contract_name) { "BaseContract" }
+    let(:operation) { proc { raise StandardError, "some error" } }
+
+    it "raises an error right away, does not sample, does not log" do
+      not_expect_sample
+      not_expect_log
+
+      expect { result }.to raise_error(StandardError, "some error")
+    end
+  end
+end

--- a/spec/contr/base/shared_examples/contract_failed_in_async_check_with_async_rules.rb
+++ b/spec/contr/base/shared_examples/contract_failed_in_async_check_with_async_rules.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "contract failed in async check with async rules" do
+  context "when guarantees failed" do
+    before do
+      define_contract_class(contract_name, BaseContract) do
+        async pools: {rules: Contr::Async::Pool::Fixed.new}
+
+        guarantee(:g1) { true }
+        guarantee(:g2) { false }
+        expect(:e1)    { raise StandardError, "some error" }
+        expect(:e2)    { false }
+      end
+    end
+
+    let(:contract_name) { "FailedContractGuaranteesNotMatched" }
+    let(:state) do
+      {
+        ts:            "1999-01-01T00:00:00.000Z",
+        contract_name: contract_name,
+        failed_rules:  match([
+          {type: :guarantee, name: :g2, status: :failed},
+          {type: :expectation, name: :e1, status: :unexpected_error, error: be_a(StandardError)},
+          {type: :expectation, name: :e2, status: :failed}
+        ]),
+        ok_rules: [{type: :guarantee, name: :g1, status: :ok}],
+        async:    true,
+        args:     [1, 2, 3],
+        result:   operation_result
+      }
+    end
+
+    it "creates sample and writes to log" do
+      expect_sample_with(state)
+      expect_log_with(log_state)
+
+      expect { result }.not_to raise_error
+    end
+  end
+
+  context "when expectations failed" do
+    before do
+      define_contract_class(contract_name, BaseContract) do
+        guarantee(:g1) { true }
+        guarantee(:g2) { true }
+        expect(:e1)    { raise StandardError, "some error" }
+        expect(:e2)    { false }
+        expect(:e3)    { false }
+      end
+    end
+
+    let(:contract_name) { "FailedContractExpectationsNotMatched" }
+    let(:state) do
+      {
+        ts:            "1999-01-01T00:00:00.000Z",
+        contract_name: contract_name,
+        failed_rules:  match([
+          {type: :expectation, name: :e1, status: :unexpected_error, error: be_a(StandardError)},
+          {type: :expectation, name: :e2, status: :failed},
+          {type: :expectation, name: :e3, status: :failed}
+        ]),
+        ok_rules: match([
+          {type: :guarantee, name: :g1, status: :ok},
+          {type: :guarantee, name: :g2, status: :ok}
+        ]),
+        async:  true,
+        args:   [1, 2, 3],
+        result: operation_result
+      }
+    end
+
+    it "creates sample and writes to log" do
+      expect_sample_with(state)
+      expect_log_with(log_state)
+
+      expect { result }.not_to raise_error
+    end
+  end
+
+  context "when sampler and logger are disabled" do
+    before do
+      define_contract_class(contract_name, BaseContract) do
+        logger nil
+        sampler nil
+
+        guarantee(:g1) { false }
+      end
+    end
+
+    let(:contract_name) { "FailedContractSamplerAndLoggerDisabled" }
+
+    it "does not sample, does not log" do
+      not_expect_sample
+      not_expect_log
+
+      expect { result }.not_to raise_error
+    end
+  end
+
+  context "when sample already exists" do
+    before do
+      define_contract_class(contract_name, BaseContract) do
+        guarantee(:g1) { false }
+      end
+
+      create_empty_file(dump_info[:path])
+    end
+
+    let(:contract_name) { "FailedContractSampleExists" }
+    let(:state) do
+      {
+        ts:            "1999-01-01T00:00:00.000Z",
+        contract_name: contract_name,
+        failed_rules:  [{type: :guarantee, name: :g1, status: :failed}],
+        ok_rules:      [],
+        async:         true,
+        args:          [1, 2, 3],
+        result:        operation_result
+      }
+    end
+
+    it "does not create new sample, logs original state" do
+      expect_sample_with(state)
+      expect_log_with(state)
+
+      expect { result }.not_to raise_error
+    end
+  end
+end

--- a/spec/contr/base/shared_examples/contract_failed_in_async_check_with_sync_rules.rb
+++ b/spec/contr/base/shared_examples/contract_failed_in_async_check_with_sync_rules.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "contract failed in async check with sync rules" do
+  context "when guarantees failed" do
+    before do
+      define_contract_class(contract_name, BaseContract) do
+        guarantee(:g1) { true }
+        guarantee(:g2) { false }
+        expect(:e1)    { raise StandardError, "some error" }
+        expect(:e2)    { false }
+      end
+    end
+
+    let(:contract_name) { "FailedContractGuaranteesNotMatched" }
+    let(:state) do
+      {
+        ts:            "1999-01-01T00:00:00.000Z",
+        contract_name: contract_name,
+        failed_rules:  [{type: :guarantee, name: :g2, status: :failed}],
+        ok_rules:      [{type: :guarantee, name: :g1, status: :ok}],
+        async:         true,
+        args:          [1, 2, 3],
+        result:        operation_result
+      }
+    end
+
+    it "creates sample and writes to log" do
+      expect_sample_with(state)
+      expect_log_with(log_state)
+
+      expect { result }.not_to raise_error
+    end
+  end
+
+  context "when expectations failed" do
+    before do
+      define_contract_class(contract_name, BaseContract) do
+        guarantee(:g1) { true }
+        guarantee(:g2) { true }
+        expect(:e1)    { raise StandardError, "some error" }
+        expect(:e2)    { false }
+        expect(:e3)    { false }
+      end
+    end
+
+    let(:contract_name) { "FailedContractExpectationsNotMatched" }
+    let(:state) do
+      {
+        ts:            "1999-01-01T00:00:00.000Z",
+        contract_name: contract_name,
+        failed_rules: [
+          {type: :expectation, name: :e1, status: :unexpected_error, error: be_a(StandardError)},
+          {type: :expectation, name: :e2, status: :failed},
+          {type: :expectation, name: :e3, status: :failed}
+        ],
+        ok_rules: [
+          {type: :guarantee, name: :g1, status: :ok},
+          {type: :guarantee, name: :g2, status: :ok}
+        ],
+        async:  true,
+        args:   [1, 2, 3],
+        result: operation_result
+      }
+    end
+
+    it "creates sample and writes to log" do
+      expect_sample_with(state)
+      expect_log_with(log_state)
+
+      expect { result }.not_to raise_error
+    end
+  end
+
+  context "when sampler and logger are disabled" do
+    before do
+      define_contract_class(contract_name, BaseContract) do
+        logger nil
+        sampler nil
+
+        guarantee(:g1) { false }
+      end
+    end
+
+    let(:contract_name) { "FailedContractSamplerAndLoggerDisabled" }
+
+    it "does not sample, does not log" do
+      not_expect_sample
+      not_expect_log
+
+      expect { result }.not_to raise_error
+    end
+  end
+
+  context "when sample already exists" do
+    before do
+      define_contract_class(contract_name, BaseContract) do
+        guarantee(:g1) { false }
+      end
+
+      create_empty_file(dump_info[:path])
+    end
+
+    let(:contract_name) { "FailedContractSampleExists" }
+    let(:state) do
+      {
+        ts:            "1999-01-01T00:00:00.000Z",
+        contract_name: contract_name,
+        failed_rules:  [{type: :guarantee, name: :g1, status: :failed}],
+        ok_rules:      [],
+        async:         true,
+        args:          [1, 2, 3],
+        result:        operation_result
+      }
+    end
+
+    it "does not create new sample, logs original state" do
+      expect_sample_with(state)
+      expect_log_with(state)
+
+      expect { result }.not_to raise_error
+    end
+  end
+end

--- a/spec/contr/base/shared_examples/contract_failed_in_sync_check.rb
+++ b/spec/contr/base/shared_examples/contract_failed_in_sync_check.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "contract failed in sync check" do
+  context "when guarantees failed" do
+    before do
+      define_contract_class(contract_name, BaseContract) do
+        guarantee(:g1) { true }
+        guarantee(:g2) { false }
+        expect(:e1)    { raise StandardError, "some error" }
+        expect(:e2)    { false }
+      end
+    end
+
+    let(:contract_name) { "FailedContractGuaranteesNotMatched" }
+    let(:state) do
+      {
+        ts:            "1999-01-01T00:00:00.000Z",
+        contract_name: contract_name,
+        failed_rules:  [{type: :guarantee, name: :g2, status: :failed}],
+        ok_rules:      [{type: :guarantee, name: :g1, status: :ok}],
+        async:         false,
+        args:          [1, 2, 3],
+        result:        operation_result
+      }
+    end
+
+    it "creates sample, writes to log and raises an error" do
+      expect_sample_with(state)
+      expect_log_with(log_state)
+
+      expect { result }.to raise_error(
+        Contr::Matcher::GuaranteesNotMatched,
+        "failed rules: [[:guarantee, :g2, :failed]], args: [1, 2, 3]"
+      )
+    end
+  end
+
+  context "when expectations failed" do
+    before do
+      define_contract_class(contract_name, BaseContract) do
+        guarantee(:g1) { true }
+        guarantee(:g2) { true }
+        expect(:e1)    { raise StandardError, "some error" }
+        expect(:e2)    { false }
+        expect(:e3)    { false }
+      end
+    end
+
+    let(:contract_name) { "FailedContractExpectationsNotMatched" }
+    let(:state) do
+      {
+        ts:            "1999-01-01T00:00:00.000Z",
+        contract_name: contract_name,
+        failed_rules: [
+          {type: :expectation, name: :e1, status: :unexpected_error, error: be_a(StandardError)},
+          {type: :expectation, name: :e2, status: :failed},
+          {type: :expectation, name: :e3, status: :failed}
+        ],
+        ok_rules: [
+          {type: :guarantee, name: :g1, status: :ok},
+          {type: :guarantee, name: :g2, status: :ok}
+        ],
+        async:  false,
+        args:   [1, 2, 3],
+        result: operation_result
+      }
+    end
+
+    it "creates sample, writes to log and raises an error" do
+      expect_sample_with(state)
+      expect_log_with(log_state)
+
+      expect { result }.to raise_error(
+        Contr::Matcher::ExpectationsNotMatched,
+        "failed rules: [[:expectation, :e1, :unexpected_error, #<StandardError: some error>], [:expectation, :e2, :failed], [:expectation, :e3, :failed]], args: [1, 2, 3]"
+      )
+    end
+  end
+
+  context "when sampler and logger are disabled" do
+    before do
+      define_contract_class(contract_name, BaseContract) do
+        logger nil
+        sampler nil
+
+        guarantee(:g1) { false }
+      end
+    end
+
+    let(:contract_name) { "FailedContractSamplerAndLoggerDisabled" }
+
+    it "raises an error, does not sample, does not log" do
+      not_expect_sample
+      not_expect_log
+
+      expect { result }.to raise_error(
+        Contr::Matcher::GuaranteesNotMatched,
+        "failed rules: [[:guarantee, :g1, :failed]], args: [1, 2, 3]"
+      )
+    end
+  end
+
+  context "when sample already exists" do
+    before do
+      define_contract_class(contract_name, BaseContract) do
+        guarantee(:g1) { false }
+      end
+
+      create_empty_file(dump_info[:path])
+    end
+
+    let(:contract_name) { "FailedContractSampleExists" }
+    let(:state) do
+      {
+        ts:            "1999-01-01T00:00:00.000Z",
+        contract_name: contract_name,
+        failed_rules:  [{type: :guarantee, name: :g1, status: :failed}],
+        ok_rules:      [],
+        async:         false,
+        args:          [1, 2, 3],
+        result:        operation_result
+      }
+    end
+
+    it "does not create new sample, logs original state and raises an error" do
+      expect_sample_with(state)
+      expect_log_with(state)
+
+      expect { result }.to raise_error(
+        Contr::Matcher::GuaranteesNotMatched,
+        "failed rules: [[:guarantee, :g1, :failed]], args: [1, 2, 3]"
+      )
+    end
+  end
+end

--- a/spec/contr/base/shared_examples/contract_matched.rb
+++ b/spec/contr/base/shared_examples/contract_matched.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "contract matched" do
+  context "without unexpected errors in rules" do
+    context "with both guarantees and expectations" do
+      before do
+        define_contract_class(contract_name, BaseContract) do
+          guarantee(:g1) { true }
+          guarantee(:g2) { true }
+          expect(:e1)    { false }
+          expect(:e2)    { true }
+        end
+      end
+
+      let(:contract_name) { "OkContractNoUnexpectedErrors" }
+
+      it "returns operation result, does not sample, does not log" do
+        not_expect_sample
+        not_expect_log
+
+        expect(result).to eq operation_result
+      end
+    end
+
+    context "with guarantees only" do
+      before do
+        define_contract_class(contract_name, BaseContract) do
+          guarantee(:g1) { true }
+          guarantee(:g2) { true }
+        end
+      end
+
+      let(:contract_name) { "OkContractGuaranteesOnly" }
+
+      it "returns operation result, does not sample, does not log" do
+        not_expect_sample
+        not_expect_log
+
+        expect(result).to eq operation_result
+      end
+    end
+
+    context "with expectations only" do
+      before do
+        define_contract_class(contract_name, BaseContract) do
+          expect(:e1) { false }
+          expect(:e2) { true }
+        end
+      end
+
+      let(:contract_name) { "OkContractExpectationsOnly" }
+
+      it "returns operation result, does not sample, does not log" do
+        not_expect_sample
+        not_expect_log
+
+        expect(result).to eq operation_result
+      end
+    end
+  end
+
+  context "with unexpected error in some of the expectations" do
+    before do
+      define_contract_class(contract_name, BaseContract) do
+        guarantee(:g1) { true }
+        guarantee(:g2) { true }
+        expect(:e1)    { raise StandardError, "some error" }
+        expect(:e2)    { true }
+      end
+    end
+
+    let(:contract_name) { "OkContractUnexpectedErrorInExpectation" }
+
+    it "returns operation result, does not sample, does not log" do
+      not_expect_sample
+      not_expect_log
+
+      expect(result).to eq operation_result
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,9 @@ require "contr"
 # require all spec `support` files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
 
+# require all shared examples and contexts for `base`
+Dir["#{File.dirname(__FILE__)}/contr/base/**/*.rb"].sort.each { |f| require f }
+
 RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true

--- a/spec/support/matchers/be_default_logger.rb
+++ b/spec/support/matchers/be_default_logger.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :be_default_logger do
+  match do |actual|
+    actual.instance_of?(Contr::Logger::Default)
+  end
+end

--- a/spec/support/matchers/be_default_sampler.rb
+++ b/spec/support/matchers/be_default_sampler.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :be_default_sampler do
+  match do |actual|
+    actual.instance_of?(Contr::Sampler::Default)
+  end
+end

--- a/spec/support/matchers/be_fixed_async_pool.rb
+++ b/spec/support/matchers/be_fixed_async_pool.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :be_fixed_async_pool do |opts = {}|
+  match do |actual|
+    max_threads = opts[:max_threads] || Concurrent.processor_count
+
+    actual.instance_of?(Contr::Async::Pool::Fixed) \
+      && actual.executor.max_length == max_threads \
+      && actual.executor.min_length == 0
+  end
+end

--- a/spec/support/matchers/be_global_io_async_pool.rb
+++ b/spec/support/matchers/be_global_io_async_pool.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :be_global_io_async_pool do
+  match do |actual|
+    actual.instance_of?(Contr::Async::Pool::GlobalIO) && actual.executor == Concurrent.global_io_executor
+  end
+end


### PR DESCRIPTION
Async backend considerations:

- `concurrent-ruby` - thread-based, compatible with basically everything, including different Ruby implementations, provides thread-safe primitives (of [questionable](https://github.com/ruby-concurrency/concurrent-ruby/issues/929) reliability, haha)
- `async` - fiber-based, can be a little bit more performant than `concurrent-ruby` (with correct setup), has worse compatibility with gems (especially the ones that incorporate C-extensions), as well as with alternative Ruby implementations, no thread-safe primitives out of the box
- `ractors` - x2 faster than regular threads, more restrictive than Rust's borrow checker with lifetimes of mutable references in async fn's, not compatible with basically any of the popular gems, even with the standard ones like `net/http`, not compatible with C-extensions

And the winner is - `concurrent-ruby`.

Though, there is really high temptation to throw it out in a favour of pure thread-based setup similar to the one used in `parallel`. Downside - no reusable pools. Upside - threads are killed after being used immediately, so no need to worry about thread pollution. Thing that should be tested first - how much thread allocation "on-demand" affect the performance.

Async setup:

- concurrency level of asynchronous contract checks can be limited with fixed `main` pool
- asynchronous execution of rules is available, but disabled by default, as it leads to more rules to be checked than minimally required (comparing to `sync` mode); on the other hand, contract check completes much faster
- comparison of different pools configs can be checked in benchmarks
- while there were no problems with `sampler` and `logger` under stress, technically they're still not fully thread-safe; possible solution - to move their initialisation from contract to `Matcher`, so each check will work with its own isolated copies