### PR TITLE
Freeze shared variables

### DIFF
--- a/lib/contr/base.rb
+++ b/lib/contr/base.rb
@@ -83,7 +83,8 @@ module Contr
       configs = contracts_chain.filter_map(&:config)
       configs << instance_config
 
-      configs.inject(&:deep_merge) || {}
+      merged = configs.inject(&:deep_merge) || {}
+      merged.freeze
     end
 
     def init_logger!

--- a/lib/contr/base.rb
+++ b/lib/contr/base.rb
@@ -43,7 +43,7 @@ module Contr
       end
     end
 
-    attr_reader :config, :logger, :sampler, :main_pool, :rules_pool
+    attr_reader :config, :logger, :sampler, :main_pool, :rules_pool, :guarantees, :expectations
 
     def initialize(instance_config = {})
       @config = merge_configs(instance_config)
@@ -52,6 +52,11 @@ module Contr
       init_sampler!
       init_main_pool!
       init_rules_pool!
+
+      aggregate_guarantees!
+      aggregate_expectations!
+
+      freeze
     end
 
     def check(*args)
@@ -70,14 +75,6 @@ module Contr
       self.class.name
     end
 
-    def guarantees
-      @guarantees ||= aggregate_rules(:guarantees)
-    end
-
-    def expectations
-      @expectations ||= aggregate_rules(:expectations)
-    end
-
     private
 
     using Refines::Hash
@@ -90,7 +87,7 @@ module Contr
     end
 
     def init_logger!
-      @logger ||=
+      @logger =
         case config
         in logger: nil | false
           nil
@@ -104,7 +101,7 @@ module Contr
     end
 
     def init_sampler!
-      @sampler ||=
+      @sampler =
         case config
         in sampler: nil | false
           nil
@@ -118,7 +115,7 @@ module Contr
     end
 
     def init_main_pool!
-      @main_pool ||=
+      @main_pool =
         case config.dig(:async, :pools)
         in main: nil | false
           raise ArgumentError, "main pool can't be disabled"
@@ -132,7 +129,7 @@ module Contr
     end
 
     def init_rules_pool!
-      @rules_pool ||=
+      @rules_pool =
         case config.dig(:async, :pools)
         in rules: nil | false
           nil
@@ -143,6 +140,14 @@ module Contr
         else
           nil
         end
+    end
+
+    def aggregate_guarantees!
+      @guarantees = aggregate_rules(:guarantees).freeze
+    end
+
+    def aggregate_expectations!
+      @expectations = aggregate_rules(:expectations).freeze
     end
 
     def aggregate_rules(rule_type)

--- a/lib/contr/matcher.rb
+++ b/lib/contr/matcher.rb
@@ -25,12 +25,12 @@ module Contr
     class Base
       extend Forwardable
 
-      def_delegators :@contract, :guarantees, :expectations, :logger, :sampler, :main_pool, :rules_pool
+      def_delegators :@contract, :logger, :sampler, :main_pool, :rules_pool, :guarantees, :expectations
 
       def initialize(contract, args, result)
         @contract = contract
-        @args     = args
-        @result   = result
+        @args     = args.freeze
+        @result   = result.freeze
       end
 
       def match

--- a/spec/contr/base_spec.rb
+++ b/spec/contr/base_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Contr::Base do
         expect(contract.main_pool).to be_fixed_async_pool
         expect(contract.rules_pool).to be_nil
         expect(contract.name).to eq "ContractWithoutRules"
+        expect(contract.frozen?).to eq true
       end
     end
 
@@ -279,7 +280,7 @@ RSpec.describe Contr::Base do
     subject(:result) { contract.check_async(*args) { operation.call } }
 
     context "with async rules" do
-      context "using default pool" do
+      context "using fixed pool" do
         before do
           define_contract_class("BaseContract", PreConfiguredContract) do
             async pools: {rules: Contr::Async::Pool::Fixed.new}
@@ -293,13 +294,10 @@ RSpec.describe Contr::Base do
         it_behaves_like "contract failed in async check with async rules"
       end
 
-      context "using global pools" do
+      context "using global pool" do
         before do
           define_contract_class("BaseContract", PreConfiguredContract) do
-            async pools: {
-              main: Contr::Async::Pool::Fixed.new,
-              rules: Contr::Async::Pool::GlobalIO.new
-            }
+            async pools: {rules: Contr::Async::Pool::GlobalIO.new}
           end
 
           run_async_matcher_inline!

--- a/spec/contr/base_spec.rb
+++ b/spec/contr/base_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Contr::Base do
         expect(contract.rules_pool).to be_nil
         expect(contract.name).to eq "ContractWithoutRules"
         expect(contract.frozen?).to eq true
+        expect(contract.config.frozen?).to eq true
       end
     end
 

--- a/spec/support/class_helpers.rb
+++ b/spec/support/class_helpers.rb
@@ -6,7 +6,7 @@ module ClassHelpers
     stub_const(class_name, klass)
   end
 
-  def define_contract_class(contract_name, superclass = described_class, &block)
+  def define_contract_class(contract_name, superclass = Contr::Base, &block)
     define_class(contract_name, superclass, &block)
   end
 end


### PR DESCRIPTION
Makes sure that all shared variables that are used in contract checks are frozen.
Questionable thread safety still in place for `logger` and `sampler` (can't trigger any problem though).